### PR TITLE
Fix Flask async issue when starting a teleport server locally

### DIFF
--- a/backend/servers/flask-webrouter/scripts/<REPLACE>localhost_start.sh
+++ b/backend/servers/flask-webrouter/scripts/<REPLACE>localhost_start.sh
@@ -7,5 +7,5 @@ fi
 if [ "$MODE" != "localhost" ] ; then
   $[manageExtraConfig] export URL=$[run.url] && uwsgi $VIRTUAL_ENV_OPTION --ini config/localhost_uwsgi.ini
 else
-  $[manageExtraConfig] export URL=$[run.url] && python scripts/manage.py runserver
+  $[manageExtraConfig] export URL=$[run.url] && uwsgi $VIRTUAL_ENV_OPTION --py-autoreload 1 --ini config/localhost_uwsgi.ini
 fi


### PR DESCRIPTION
It seems that Flask alone cannot handle properly asynchronous calls. It especially happens when combining a teleport webpack frontend template with this one.

To manage the network stack we need uwsgi (even on local development) on top of Flask.

Nb: the `--py-autoreload` option let uwsgi reload the flask server automatically on changes; useful for dev. 

@pocketjoso @ClemDelp @Ledoux 